### PR TITLE
update scala to 2.12 and deps to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 name := """reactivecouchbase-rs-core"""
 organization := "org.reactivecouchbase"
 version := "1.0.0-SNAPSHOT"
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.1",
-  "com.couchbase.client" % "java-client" % "2.4.1",
-  "com.typesafe.play" %% "play-json" % "2.4.10",
-  "com.typesafe.akka" %% "akka-actor" % "2.4.11.1",
-  "com.typesafe.akka" %% "akka-stream" % "2.4.11.1",
+  "com.couchbase.client" % "java-client" % "2.4.5",
+  "com.typesafe.play" %% "play-json" % "2.6.0-RC2",
+  "com.typesafe.akka" %% "akka-actor" % "2.5.2",
+  "com.typesafe.akka" %% "akka-stream" % "2.5.2",
   "io.reactivex" % "rxjava-reactive-streams" % "1.2.1",
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.2" % "test"
 ) 
 
 val local: Project.Initialize[Option[sbt.Resolver]] = version { (version: String) =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Feb 08 08:51:11 CET 2017
 template.uuid=e17acfbb-1ff5-41f5-b8cf-2c40be6a8340
-sbt.version=0.13.8
+sbt.version=0.13.15


### PR DESCRIPTION
Hi @mathieuancelin, 
would you consider updating library to work with scala 2.12?
It should be possible to cross-compile it to 2.11, looks like that all the deps are still available in 2.11 