### PR TITLE
Retries and getFromReplica functionalities

### DIFF
--- a/src/main/scala/org/reactivecouchbase/rs/scaladsl/Retries.scala
+++ b/src/main/scala/org/reactivecouchbase/rs/scaladsl/Retries.scala
@@ -1,0 +1,55 @@
+package org.reactivecouchbase.rs.scaladsl
+
+/**
+  * Handles the retries on error. Similar to `RetryBuilder` of java client of couchbase.
+  */
+object Retries {
+
+  import scala.concurrent._
+  import scala.concurrent.duration._
+  import akka.pattern.after
+  import akka.actor.Scheduler
+
+  /**
+    * Tries to invoke a future block as many time as asked on occurrence of a specific type of error. A fix delay/interval
+    * is applied before each invocation.
+    * Note that if the errors keep occurring more than the maximum allowed number of attempts, the last error that
+    * triggered the extraneous attempt will be wrapped as the cause inside a CannotRetryException
+    *
+    * @param retries   Number of retries to be made
+    * @param delay     Interval between two consecutive retries
+    * @param errFilter Function to filter a specific type of error
+    * @param f         Block of code to be retried, so this should be the couchbase query to retry on failure
+    * @param ec        Execution context
+    * @param s         Scheduler
+    * @tparam T Type of result
+    * @return Either the result inside a future or an exception
+    */
+  def retryOnError[T](
+                       retries: Int = 1,
+                       delay: FiniteDuration = 0.millis,
+                       errFilter: Throwable => Boolean = _ => true
+                     )(
+                       f: => Future[T]
+                     )(
+                       implicit ec: ExecutionContext,
+                       s: Scheduler
+                     ): Future[T] = {
+    f recoverWith {
+      case e if errFilter(e) && retries > 0 =>
+        after(delay, s)(retryOnError(retries - 1, delay)(f))
+
+      case e if errFilter(e) && retries == 0 =>
+        Future.failed(CannotRetryException(s"All retries failed because of ${e.getMessage}"))
+    }
+
+  }
+}
+
+
+/**
+  * Thrown exception if error persist even after maximum number of retries.
+  *
+  * @param message Message exception
+  */
+case class CannotRetryException(message: String) extends RuntimeException(message)

--- a/src/test/scala/RetriesTest.scala
+++ b/src/test/scala/RetriesTest.scala
@@ -1,0 +1,46 @@
+import akka.actor.ActorSystem
+import org.reactivecouchbase.rs.scaladsl.CannotRetryException
+import org.reactivecouchbase.rs.scaladsl.Retries._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, MustMatchers}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+/**
+  * Test suite for retries.
+  */
+class RetriesTest extends FlatSpec with ScalaFutures with MustMatchers with BeforeAndAfterAll {
+
+  val actorSystem = ActorSystem()
+  implicit val ec = actorSystem.dispatcher
+  implicit val sched = actorSystem.scheduler
+
+  def doSomethingGood(): Future[String] = {
+    println("good")
+    Future.successful("SUCCESS")
+  }
+
+  def doSomethingBad(): Future[String] = {
+    println("bad")
+    Future.failed(new RuntimeException("FAILURE"))
+  }
+
+  "Retries" should "not retry when passing a good computation" in {
+
+    val result = retryOnError(3, 2.millis)(doSomethingGood())
+
+    result.futureValue mustBe ("SUCCESS")
+
+  }
+
+  "Retries" should "fail after max retries when passing a bad computation" in {
+
+    retryOnError(3, 2.millis)(doSomethingBad()).failed.futureValue mustBe an[CannotRetryException]
+  }
+
+  override protected def afterAll(): Unit = {
+    actorSystem.terminate()
+  }
+
+}


### PR DESCRIPTION
Pull request contains two supplementary functionalities (both inspired from couchbase java client)

1. **Retries** : Same as _RetryBuilder_ of java client which retries the couchbase query on error.

2. **getFromReplica** : This bucket function is used to search one or many replicas of couchbase when the document being searched isn't found.
