### PR TITLE
Adds support for timeouts as current operations have infinite timeouts.

### DIFF
--- a/src/main/scala/org/reactivecouchbase/rs/scaladsl/Bucket.scala
+++ b/src/main/scala/org/reactivecouchbase/rs/scaladsl/Bucket.scala
@@ -29,15 +29,16 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.reflect._
 
-case class BucketConfig(name: String, password: Option[String] = None, hosts: Seq[String], env: EnvCustomizer)
+case class BucketConfig(name: String, password: Option[String] = None, hosts: Seq[String], env: EnvCustomizer, defaultTimeout: Option[Duration])
 
 object BucketConfig {
   import collection.JavaConversions._
-  def apply(config: Config, env: EnvCustomizer): BucketConfig = {
+
+  def apply(config: Config, env: EnvCustomizer, defaultTimeout: Option[Duration]): BucketConfig = {
     val name = Try(config.getString("name")).get
     val password = Try(config.getString("password")).toOption
     val hosts = Try(config.getStringList("hosts")).get.toIndexedSeq
-    BucketConfig(name, password, hosts, env)
+    BucketConfig(name, password, hosts, env, defaultTimeout)
   }
 }
 
@@ -74,11 +75,11 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def tailSearchFlow[T](query: Long => QueryLike, extractor: (T, Long) => Long, from: Long = 0L)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, T, NotUsed] = {
+  def tailSearchFlow[T](query: Long => QueryLike, extractor: (T, Long) => Long, from: Long = 0L, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, T, NotUsed] = {
     val ref = new AtomicReference[Long](from)
     val last = new AtomicReference[T]()
     Flow[NotUsed].flatMapConcat { _ =>
-      search[T](query(ref.get()))(ec, mat, reader)
+      search[T](query(ref.get()), timeout)(ec, mat, reader)
         .asSource
         .map { item =>
           last.set(item)
@@ -90,11 +91,11 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
     }
   }
 
-  def tailViewSearchFlow[T](query: Long => ViewQuery, extractor: (ViewRow[T], Long) => Long, from: Long = 0L)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, ViewRow[T], NotUsed] = {
+  def tailViewSearchFlow[T](query: Long => ViewQuery, extractor: (ViewRow[T], Long) => Long, from: Long = 0L, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, ViewRow[T], NotUsed] = {
     val ref = new AtomicReference[Long](from)
     val last = new AtomicReference[ViewRow[T]]()
     Flow[NotUsed].flatMapConcat { _ =>
-      searchView[T](query(ref.get()))(ec, mat, reader)
+      searchView[T](query(ref.get()), timeout)(ec, mat, reader)
         .asSource
         .map { item =>
           last.set(item)
@@ -106,11 +107,11 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
     }
   }
 
-  def tailSpatialSearchFlow[T](query: Long => SpatialQuery, extractor: (SpatialViewRow[T], Long) => Long, from: Long = 0L)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, SpatialViewRow[T], NotUsed] = {
+  def tailSpatialSearchFlow[T](query: Long => SpatialQuery, extractor: (SpatialViewRow[T], Long) => Long, from: Long = 0L, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[NotUsed, SpatialViewRow[T], NotUsed] = {
     val ref = new AtomicReference[Long](from)
     val last = new AtomicReference[SpatialViewRow[T]]()
     Flow[NotUsed].flatMapConcat { _ =>
-      searchSpatial[T](query(ref.get()))(ec, mat, reader)
+      searchSpatial[T](query(ref.get()), timeout)(ec, mat, reader)
         .asSource
         .map { item =>
           last.set(item)
@@ -122,124 +123,124 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
     }
   }
 
-  def tailSearch[T](query: Long => QueryLike, extractor: (T, Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS))(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, Cancellable] = {
+  def tailSearch[T](query: Long => QueryLike, extractor: (T, Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS), timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, Cancellable] = {
     Source.tick(
       FiniteDuration(0, TimeUnit.MILLISECONDS),
       every,
       NotUsed
-    ).via(tailSearchFlow[T](query, extractor, from)(ec, mat, reader)).take(limit)
+    ).via(tailSearchFlow[T](query, extractor, from, timeout)(ec, mat, reader)).take(limit)
   }
 
-  def tailViewSearch[T](query: Long => ViewQuery, extractor: (ViewRow[T], Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS))(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], Cancellable] = {
+  def tailViewSearch[T](query: Long => ViewQuery, extractor: (ViewRow[T], Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS), timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], Cancellable] = {
     Source.tick(
       FiniteDuration(0, TimeUnit.MILLISECONDS),
       every,
       NotUsed
-    ).via(tailViewSearchFlow[T](query, extractor, from)(ec, mat, reader)).take(limit)
+    ).via(tailViewSearchFlow[T](query, extractor, from, timeout)(ec, mat, reader)).take(limit)
   }
 
-  def tailSpatialSearch[T](query: Long => SpatialQuery, extractor: (SpatialViewRow[T], Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS))(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], Cancellable] = {
+  def tailSpatialSearch[T](query: Long => SpatialQuery, extractor: (SpatialViewRow[T], Long) => Long, from: Long = 0L, limit: Long = Long.MaxValue, every: FiniteDuration = FiniteDuration(200, TimeUnit.MILLISECONDS), timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], Cancellable] = {
     Source.tick(
       FiniteDuration(0, TimeUnit.MILLISECONDS),
       every,
       NotUsed
-    ).via(tailSpatialSearchFlow[T](query, extractor, from)(ec, mat, reader)).take(limit)
+    ).via(tailSpatialSearchFlow[T](query, extractor, from, timeout)(ec, mat, reader)).take(limit)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def getFlow[T]()(implicit ec: ExecutionContext, reader: JsonReads[T]): Flow[String, T, NotUsed] = {
-    Flow[String].flatMapConcat(k => Source.fromFuture(get[T](k)(ec, reader))).filter(_.isDefined).map(_.get)
+  def getFlow[T](timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Flow[String, T, NotUsed] = {
+    Flow[String].flatMapConcat(k => Source.fromFuture(get[T](k, timeout)(ec, reader))).filter(_.isDefined).map(_.get)
   }
 
-  def getFromSource[T, Mat](keys: Source[String, Mat])(implicit ec: ExecutionContext, reader: JsonReads[T]): Source[T, Mat] = {
-    keys.via(getFlow[T]()(ec, reader))
+  def getFromSource[T, Mat](keys: Source[String, Mat], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Source[T, Mat] = {
+    keys.via(getFlow[T](timeout)(ec, reader))
   }
 
-  def getFromPublisher[T](keys: Publisher[String])(implicit ec: ExecutionContext, reader: JsonReads[T]): Source[T, NotUsed] = {
-    getFromSource[T, NotUsed](Source.fromPublisher(keys))(ec, reader)
-  }
-
-  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  def removeFlow(settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Flow[String, Boolean, NotUsed] = {
-    Flow[String].flatMapConcat(k => Source.fromFuture(remove(k, settings)(ec)))
-  }
-
-  def removeFromSource[Mat](keys: Source[String, Mat], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Source[Boolean, Mat] = {
-    keys.via(removeFlow(settings)(ec))
-  }
-
-  def removeFromPublisher(keys: Publisher[String], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Source[Boolean, NotUsed] = {
-    removeFromSource[NotUsed](Source.fromPublisher(keys), settings)(ec)
+  def getFromPublisher[T](keys: Publisher[String], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Source[T, NotUsed] = {
+    getFromSource[T, NotUsed](Source.fromPublisher(keys), timeout)(ec, reader)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def insertFlow[T](settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Flow[(String, T), T, NotUsed] = {
-    Flow[(String, T)].flatMapConcat(tuple => Source.fromFuture(insert[T](tuple._1, tuple._2, settings)(ec, format)))
+  def removeFlow(settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Flow[String, Boolean, NotUsed] = {
+    Flow[String].flatMapConcat(k => Source.fromFuture(remove(k, settings, timeout)(ec)))
   }
 
-  def insertFromSource[T, Mat](values: Source[(String, T), Mat], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, Mat] = {
-    values.via(insertFlow[T](settings)(ec, format))
+  def removeFromSource[Mat](keys: Source[String, Mat], settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Source[Boolean, Mat] = {
+    keys.via(removeFlow(settings, timeout)(ec))
   }
 
-  def insertFromPublisher[T](values: Publisher[(String, T)], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, NotUsed] = {
-    insertFromSource[T, NotUsed](Source.fromPublisher(values), settings)(ec, format)
+  def removeFromPublisher(keys: Publisher[String], settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Source[Boolean, NotUsed] = {
+    removeFromSource[NotUsed](Source.fromPublisher(keys), settings, timeout)(ec)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def upsertFlow[T](settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Flow[(String, T), T, NotUsed] = {
+  def insertFlow[T](settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Flow[(String, T), T, NotUsed] = {
+    Flow[(String, T)].flatMapConcat(tuple => Source.fromFuture(insert[T](tuple._1, tuple._2, settings, cas, timeout)(ec, format)))
+  }
+
+  def insertFromSource[T, Mat](values: Source[(String, T), Mat], settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, Mat] = {
+    values.via(insertFlow[T](settings, cas, timeout)(ec, format))
+  }
+
+  def insertFromPublisher[T](values: Publisher[(String, T)], settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, NotUsed] = {
+    insertFromSource[T, NotUsed](Source.fromPublisher(values), settings, cas, timeout)(ec, format)
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  def upsertFlow[T](settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Flow[(String, T), T, NotUsed] = {
     Flow[(String, T)].flatMapConcat(tuple => Source.fromFuture(upsert[T](tuple._1, tuple._2, settings)(ec, format)))
   }
 
-  def upsertFromSource[T, Mat](values: Source[(String, T), Mat], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, Mat] = {
-    values.via(upsertFlow[T](settings)(ec, format))
+  def upsertFromSource[T, Mat](values: Source[(String, T), Mat], settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, Mat] = {
+    values.via(upsertFlow[T](settings, cas, timeout)(ec, format))
   }
 
-  def upsertFromPublisher[T](values: Publisher[(String, T)], settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, NotUsed] = {
-    upsertFromSource[T, NotUsed](Source.fromPublisher(values), settings)(ec, format)
+  def upsertFromPublisher[T](values: Publisher[(String, T)], settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Source[T, NotUsed] = {
+    upsertFromSource[T, NotUsed](Source.fromPublisher(values), settings, cas, timeout)(ec, format)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def searchFlow[T]()(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[QueryLike, T, NotUsed] = {
-    Flow[QueryLike].flatMapConcat(query => search[T](query)(ec, mat, reader).asSource)
+  def searchFlow[T](timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[QueryLike, T, NotUsed] = {
+    Flow[QueryLike].flatMapConcat(query => search[T](query, timeout)(ec, mat, reader).asSource)
   }
 
-  def searchFromSource[T, Mat](query: Source[QueryLike, Mat])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, Mat] = {
-    query.via(searchFlow[T]()(ec, mat, reader))
+  def searchFromSource[T, Mat](query: Source[QueryLike, Mat], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, Mat] = {
+    query.via(searchFlow[T](timeout)(ec, mat, reader))
   }
 
-  def searchFromPublisher[T](query: Publisher[QueryLike])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, NotUsed] = {
-    searchFromSource[T, NotUsed](Source.fromPublisher(query))(ec, mat, reader)
+  def searchFromPublisher[T](query: Publisher[QueryLike], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[T, NotUsed] = {
+    searchFromSource[T, NotUsed](Source.fromPublisher(query), timeout)(ec, mat, reader)
   }
 
-  def searchViewFlow[T]()(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[ViewQuery, ViewRow[T], NotUsed] = {
+  def searchViewFlow[T](timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[ViewQuery, ViewRow[T], NotUsed] = {
     Flow[ViewQuery].flatMapConcat(query => searchView[T](query)(ec, mat, reader).asSource)
   }
 
-  def searchViewFromSource[T, Mat](query: Source[ViewQuery, Mat])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], Mat] = {
-    query.via(searchViewFlow[T]()(ec, mat, reader))
+  def searchViewFromSource[T, Mat](query: Source[ViewQuery, Mat], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], Mat] = {
+    query.via(searchViewFlow[T](timeout)(ec, mat, reader))
   }
 
-  def searchViewFromPublisher[T](query: Publisher[ViewQuery])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], NotUsed] = {
-    searchViewFromSource[T, NotUsed](Source.fromPublisher(query))(ec, mat, reader)
+  def searchViewFromPublisher[T](query: Publisher[ViewQuery], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[ViewRow[T], NotUsed] = {
+    searchViewFromSource[T, NotUsed](Source.fromPublisher(query), timeout)(ec, mat, reader)
   }
 
-  def searchSpatialFlow[T]()(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[SpatialQuery, SpatialViewRow[T], NotUsed] = {
-    Flow[SpatialQuery].flatMapConcat(query => searchSpatial[T](query)(ec, mat, reader).asSource)
+  def searchSpatialFlow[T](timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Flow[SpatialQuery, SpatialViewRow[T], NotUsed] = {
+    Flow[SpatialQuery].flatMapConcat(query => searchSpatial[T](query, timeout)(ec, mat, reader).asSource)
   }
 
-  def searchSpatialFromSource[T, Mat](query: Source[SpatialQuery, Mat])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], Mat] = {
-    query.via(searchSpatialFlow[T]()(ec, mat, reader))
+  def searchSpatialFromSource[T, Mat](query: Source[SpatialQuery, Mat], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], Mat] = {
+    query.via(searchSpatialFlow[T](timeout)(ec, mat, reader))
   }
 
-  def searchSpatialFromPublisher[T](query: Publisher[SpatialQuery])(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], NotUsed] = {
-    searchSpatialFromSource[T, NotUsed](Source.fromPublisher(query))(ec, mat, reader)
+  def searchSpatialFromPublisher[T](query: Publisher[SpatialQuery], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): Source[SpatialViewRow[T], NotUsed] = {
+    searchSpatialFromSource[T, NotUsed](Source.fromPublisher(query), timeout)(ec, mat, reader)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -247,121 +248,121 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   object maps {
-    def put[T](key: String, entry: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def put[T](key: String, entry: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.mapAdd(key, entry, slug).asFuture.map(_.booleanValue)
+        bucket.mapAdd(key, entry, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def get[T](key: String, entry: String)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
+    def get[T](key: String, entry: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
       _futureBucket.flatMap { bucket =>
-        bucket.mapGet(key, entry, classTag.runtimeClass.asInstanceOf[Class[T]]).asFuture.map(Option.apply).recover {
+        bucket.mapGet(key, entry, classTag.runtimeClass.asInstanceOf[Class[T]]).maybeTimeout(timeout).asFuture.map(Option.apply).recover {
           case e: PathNotFoundException => None
         }
       }
     }
-    def remove[T](key: String, entry: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def remove[T](key: String, entry: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.mapRemove(key, entry).asFuture.map(_.booleanValue)
+        bucket.mapRemove(key, entry).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def size(key: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def size(key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Int] = {
       _futureBucket.flatMap { bucket =>
-        bucket.mapSize(key).asFuture.map(_.toInt)
+        bucket.mapSize(key).maybeTimeout(timeout).asFuture.map(_.toInt)
       }
     }
   }
 
   object queues {
-    def push[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def push[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.queuePush(key, slug).asFuture.map(_.booleanValue)
+        bucket.queuePush(key, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def pop[T](key: String)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
+    def pop[T](key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
       _futureBucket.flatMap { bucket =>
-        bucket.queuePop(key, classTag.runtimeClass.asInstanceOf[Class[T]]).asFuture.map(Option.apply)
+        bucket.queuePop(key, classTag.runtimeClass.asInstanceOf[Class[T]]).maybeTimeout(timeout).asFuture.map(Option.apply)
       }
     }
-    def size(key: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def size(key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Int] = {
       _futureBucket.flatMap { bucket =>
-        bucket.queueSize(key).asFuture.map(_.toInt)
+        bucket.queueSize(key).maybeTimeout(timeout).asFuture.map(_.toInt)
       }
     }
   }
 
   object lists {
-    def set[T](key: String, index: Int, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def set[T](key: String, index: Int, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listSet(key, index, slug).asFuture.map(_.booleanValue)
+        bucket.listSet(key, index, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def append[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def append[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listAppend(key, slug).asFuture.map(_.booleanValue)
+        bucket.listAppend(key, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def prepend[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def prepend[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listPrepend(key, slug).asFuture.map(_.booleanValue)
+        bucket.listPrepend(key, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def get[T](key: String, index: Int)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
+    def get[T](key: String, index: Int, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, classTag: ClassTag[T]): Future[Option[T]] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listGet(key, index, classTag.runtimeClass.asInstanceOf[Class[T]]).asFuture.map(Option.apply).recover {
+        bucket.listGet(key, index, classTag.runtimeClass.asInstanceOf[Class[T]]).maybeTimeout(timeout).asFuture.map(Option.apply).recover {
           case e: PathNotFoundException => None
         }
       }
     }
-    def remove[T](key: String, index: Int)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def remove[T](key: String, index: Int, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listRemove(key, index).asFuture.map(_.booleanValue)
+        bucket.listRemove(key, index).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def size(key: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def size(key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Int] = {
       _futureBucket.flatMap { bucket =>
-        bucket.listSize(key).asFuture.map(_.toInt)
+        bucket.listSize(key).maybeTimeout(timeout).asFuture.map(_.toInt)
       }
     }
   }
 
   object sets {
-    def add[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def add[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.setAdd(key, slug).asFuture.map(_.booleanValue)
+        bucket.setAdd(key, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
-    def remove[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Option[T]] = {
+    def remove[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Option[T]] = {
       _futureBucket.flatMap { bucket =>
-        bucket.setRemove(key, slug).asFuture.map(Option.apply).recover {
+        bucket.setRemove(key, slug).maybeTimeout(timeout).asFuture.map(Option.apply).recover {
           case e: PathNotFoundException => None
         }
       }
     }
-    def size(key: String)(implicit ec: ExecutionContext): Future[Int] = {
+    def size(key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Int] = {
       _futureBucket.flatMap { bucket =>
-        bucket.setSize(key).asFuture.map(_.toInt)
+        bucket.setSize(key).maybeTimeout(timeout).asFuture.map(_.toInt)
       }
     }
-    def contains[T](key: String, slug: T)(implicit ec: ExecutionContext): Future[Boolean] = {
+    def contains[T](key: String, slug: T, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
       _futureBucket.flatMap { bucket =>
-        bucket.setContains(key, slug).asFuture.map(_.booleanValue)
+        bucket.setContains(key, slug).maybeTimeout(timeout).asFuture.map(_.booleanValue)
       }
     }
   }
 
-  def unlock(key: String, cas: Long)(implicit ec: ExecutionContext): Future[Boolean] = {
+  def unlock(key: String, cas: Long, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
     _futureBucket.flatMap { bucket =>
-      bucket.unlock(key, cas).asFuture.map(_.booleanValue)
+      bucket.unlock(key, cas).maybeTimeout(timeout).asFuture.map(_.booleanValue)
     }
   }
-  def touch(key: String, expiry: Duration)(implicit ec: ExecutionContext): Future[Boolean] = {
+  def touch(key: String, expiry: Duration, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
     _futureBucket.flatMap { bucket =>
-      bucket.touch(key, expiry.asCouchbaseExpiry).asFuture.map(_.booleanValue)
+      bucket.touch(key, expiry.asCouchbaseExpiry).maybeTimeout(timeout).asFuture.map(_.booleanValue)
     }
   }
-  def getAndLock[T](key: String, lockTime: Duration)(implicit ec: ExecutionContext, format: JsonFormat[T], classTag: ClassTag[T]): Future[Option[T]] = {
+  def getAndLock[T](key: String, lockTime: Duration, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T], classTag: ClassTag[T]): Future[Option[T]] = {
     _futureBucket.flatMap { bucket =>
-      bucket.getAndLock(key, lockTime.toSeconds.toInt, classOf[RawJsonDocument]).asFuture
+      bucket.getAndLock(key, lockTime.toSeconds.toInt, classOf[RawJsonDocument]).maybeTimeout(timeout).asFuture
         .filter(_ != null)
         .map(doc => ByteString(doc.content()))
         .map(jsDoc => format.reads(jsDoc).asOpt).recoverWith {
@@ -371,9 +372,9 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
   }
 
   // still crappy, will add proper support later
-  def mutateIn(key: String)(f: AsyncMutateInBuilder => rx.Observable[DocumentFragment[Mutation]])(implicit ec: ExecutionContext): Future[DocumentFragment[Mutation]] = {
+  def mutateIn(key: String, timeout: Option[Duration] = config.defaultTimeout)(f: AsyncMutateInBuilder => rx.Observable[DocumentFragment[Mutation]])(implicit ec: ExecutionContext): Future[DocumentFragment[Mutation]] = {
     _futureBucket.flatMap { bucket =>
-        f(bucket.mutateIn(key)).asFuture
+        f(bucket.mutateIn(key)).maybeTimeout(timeout).asFuture
       }
   }
 
@@ -381,19 +382,19 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def incr(key: String, settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Future[Long] = counter(key, 1L, 0L, settings)(ec)
+  def incr(key: String, settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Long] = counter(key, 1L, 0L, settings, timeout)(ec)
 
-  def decr(key: String, settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Future[Long] = counter(key, -1L, 0L, settings)(ec)
+  def decr(key: String, settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Long] = counter(key, -1L, 0L, settings, timeout)(ec)
 
-  def counter(key: String, delta: Long = 0L, initialValue: Long = 0L, settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Future[Long] = {
+  def counter(key: String, delta: Long = 0L, initialValue: Long = 0L, settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Long] = {
     _futureBucket.flatMap { bucket =>
-      bucket.counter(key, delta, initialValue, settings.persistTo, settings.replicateTo).asFuture.map(_.content())
+      bucket.counter(key, delta, initialValue, settings.persistTo, settings.replicateTo).maybeTimeout(timeout).asFuture.map(_.content())
     }
   }
 
-  def counterValue(key: String, settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Future[Long] = {
+  def counterValue(key: String, settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Long] = {
     _futureBucket.flatMap { bucket =>
-      bucket.get(JsonLongDocument.create(key)).asFuture.filter(_ != null).map(_.content())
+      bucket.get(JsonLongDocument.create(key)).maybeTimeout(timeout).asFuture.filter(_ != null).map(_.content())
     }
   }
 
@@ -401,56 +402,56 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  def invalidateQueryCache()(implicit ec: ExecutionContext): Future[Int] = {
+  def invalidateQueryCache(timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Int] = {
     _futureBucket.flatMap { bucket =>
-      bucket.invalidateQueryCache().asFuture.map(_.toInt)
+      bucket.invalidateQueryCache().maybeTimeout(timeout).asFuture.map(_.toInt)
     }
   }
 
-  def close()(implicit ec: ExecutionContext): Future[Boolean] = {
+  def close(timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
     onStop()
-    _futureBucket.flatMap(_.close().asFuture.map(_.booleanValue())).andThen {
+    _futureBucket.flatMap(_.close().maybeTimeout(timeout).asFuture.map(_.booleanValue())).andThen {
       case _ => _cluster.disconnect()
-    } flatMap( _ => env.shutdownAsync().asFuture.map(_.booleanValue()))
+    } flatMap( _ => env.shutdownAsync().maybeTimeout(timeout).asFuture.map(_.booleanValue()))
   }
 
-  def cluster(implicit ec: ExecutionContext): Future[ClusterFacade] = {
-    _futureBucket.flatMap(b => b.core().asFuture)
+  def cluster(timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[ClusterFacade] = {
+    _futureBucket.flatMap(b => b.core().maybeTimeout(timeout).asFuture)
   }
 
   def environment(implicit ec: ExecutionContext): Future[CouchbaseEnvironment] = {
     _futureBucket.map(b => b.environment())
   }
 
-  def repository(implicit ec: ExecutionContext): Future[AsyncRepository] = {
-    _futureBucket.flatMap(b => b.repository().asFuture)
+  def repository(timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[AsyncRepository] = {
+    _futureBucket.flatMap(b => b.repository().maybeTimeout(timeout).asFuture)
   }
 
-  def manager(implicit ec: ExecutionContext): Future[AsyncBucketManager] = {
-    _futureBucket.flatMap(b => b.bucketManager().asFuture)
+  def manager(timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[AsyncBucketManager] = {
+    _futureBucket.flatMap(b => b.bucketManager().maybeTimeout(timeout).asFuture)
   }
 
-  def withCluster[T](f: ClusterFacade => Observable[T])(implicit ec: ExecutionContext): Future[T] = {
-    cluster(ec).flatMap(c => f(c).asFuture)
+  def withCluster[T](f: ClusterFacade => Observable[T], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[T] = {
+    cluster(timeout)(ec).flatMap(c => f(c).maybeTimeout(timeout).asFuture)
   }
 
-  def withRepository[T](f: AsyncRepository => Observable[T])(implicit ec: ExecutionContext): Future[T] = {
-    repository(ec).flatMap(r => f(r).asFuture)
+  def withRepository[T](f: AsyncRepository => Observable[T], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[T] = {
+    repository(timeout)(ec).flatMap(r => f(r).maybeTimeout(timeout).asFuture)
   }
 
   def withEnvironment[T](f: CouchbaseEnvironment => T)(implicit ec: ExecutionContext): Future[T] = {
     environment(ec).map(e => f(e))
   }
 
-  def withManager[T](f: AsyncBucketManager => Observable[T])(implicit ec: ExecutionContext): Future[T] = {
-    manager(ec).flatMap(m => f(m).asFuture)
+  def withManager[T](f: AsyncBucketManager => Observable[T], timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[T] = {
+    manager(timeout)(ec).flatMap(m => f(m).maybeTimeout(timeout).asFuture)
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-  def replace[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
+  
+  def replace[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
     _futureBucket.flatMap { bucket =>
       val doc = cas match {
         case None => RawJsonDocument.create(
@@ -469,25 +470,25 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
         doc,
         settings.persistTo,
         settings.replicateTo
-      ).asFuture.map(doc => {
+      ).maybeTimeout(timeout).asFuture.map(doc => {
         format.reads(ByteString(doc.content())).get
       })
     }
   }
 
-  def exists(key: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+  def exists(key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
     _futureBucket.flatMap { bucket =>
-      bucket.exists(key).asFuture.map(_.booleanValue())
+      bucket.exists(key).maybeTimeout(timeout).asFuture.map(_.booleanValue())
     }
   }
 
-  def remove(key: String, settings: WriteSettings = defaultWriteSettings)(implicit ec: ExecutionContext): Future[Boolean] = {
+  def remove(key: String, settings: WriteSettings = defaultWriteSettings, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext): Future[Boolean] = {
     _futureBucket.flatMap { bucket =>
-      bucket.remove(key, settings.persistTo, settings.replicateTo).asFuture.map(_ != null)
+      bucket.remove(key, settings.persistTo, settings.replicateTo).maybeTimeout(timeout).asFuture.map(_ != null)
     }
   }
 
-  def insert[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
+  def insert[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
     _futureBucket.flatMap { bucket =>
       val doc = cas match {
         case None => RawJsonDocument.create(
@@ -506,13 +507,13 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
         doc,
         settings.persistTo,
         settings.replicateTo
-      ).asFuture.map(doc => {
+      ).maybeTimeout(timeout).asFuture.map(doc => {
         format.reads(ByteString(doc.content())).get
       })
     }
   }
 
-  def upsert[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
+  def upsert[T](key: String, slug: T, settings: WriteSettings = defaultWriteSettings, cas: Option[Long] = None, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, format: JsonFormat[T]): Future[T] = {
     _futureBucket.flatMap { bucket =>
       val doc = cas match {
         case None => RawJsonDocument.create(
@@ -531,12 +532,12 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
         doc,
         settings.persistTo,
         settings.replicateTo
-      ).asFuture.map(doc => format.reads(ByteString(doc.content())).get)
+      ).maybeTimeout(timeout).asFuture.map(doc => format.reads(ByteString(doc.content())).get)
     }
   }
 
-  def get[T](key: String)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
-    _futureBucket.flatMap(b => b.get(RawJsonDocument.create(key)).asFuture)
+  def get[T](key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
+    _futureBucket.flatMap(b => b.get(RawJsonDocument.create(key)).maybeTimeout(timeout).asFuture)
       .filter(_ != null)
       .map(doc => ByteString(doc.content()))
       .map(jsDoc => reader.reads(jsDoc).asOpt).recoverWith {
@@ -544,8 +545,8 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
       }
   }
 
-  def getFromReplica[T](key: String, replicaMode: ReplicaMode)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
-    _futureBucket.flatMap(b => b.getFromReplica(RawJsonDocument.create(key), replicaMode).asFuture)
+  def getFromReplica[T](key: String, replicaMode: ReplicaMode, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
+    _futureBucket.flatMap(b => b.getFromReplica(RawJsonDocument.create(key), replicaMode).maybeTimeout(timeout).asFuture)
       .filter(_ != null)
       .map(doc => ByteString(doc.content()))
       .map(jsDoc => reader.reads(jsDoc).asOpt).recoverWith {
@@ -553,8 +554,8 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
     }
   }
 
-  def getWithCAS[T](key: String)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[(T, Long)]] = {
-    _futureBucket.flatMap(b => b.get(RawJsonDocument.create(key)).asFuture)
+  def getWithCAS[T](key: String, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[(T, Long)]] = {
+    _futureBucket.flatMap(b => b.get(RawJsonDocument.create(key)).maybeTimeout(timeout).asFuture)
       .filter(_ != null)
       .map(doc => (ByteString(doc.content()), doc.cas))
       .map {
@@ -564,8 +565,8 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
       }
   }
 
-  def getAndTouch[T](key: String, expiration:Duration)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
-    _futureBucket.flatMap(b => b.getAndTouch(key, expiration.asCouchbaseExpiry, classOf[RawJsonDocument]).asFuture)
+  def getAndTouch[T](key: String, expiration: Duration, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, reader: JsonReads[T]): Future[Option[T]] = {
+    _futureBucket.flatMap(b => b.getAndTouch(key, expiration.asCouchbaseExpiry, classOf[RawJsonDocument]).maybeTimeout(timeout).asFuture)
       .filter(_ != null)
       .map(doc => ByteString(doc.content()))
       .map(jsDoc => reader.reads(jsDoc).asOpt).recoverWith {
@@ -573,29 +574,32 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
       }
   }
 
-  def searchSpatial[T](query: SpatialQuery)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[SpatialViewRow[T], NotUsed] = {
+  def searchSpatial[T](query: SpatialQuery, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[SpatialViewRow[T], NotUsed] = {
     SimpleQueryResult(() => {
       val obs: Observable[SpatialViewRow[T]] = _asyncBucket.query(query.query)
+        .maybeTimeout(timeout)
         .flatMap(RxUtils.func1(_.rows()))
         .map(RxUtils.func1 { row => SpatialViewRow[T](row, reader) })
       Source.fromPublisher[SpatialViewRow[T]](RxReactiveStreams.toPublisher[SpatialViewRow[T]](obs))
     })
   }
 
-  def searchView[T](query: ViewQuery)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[ViewRow[T], NotUsed] = {
+  def searchView[T](query: ViewQuery, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[ViewRow[T], NotUsed] = {
     SimpleQueryResult(() => {
       val obs: Observable[ViewRow[T]] = _asyncBucket.query(query.query)
+        .maybeTimeout(timeout)
         .flatMap(RxUtils.func1(_.rows()))
         .map(RxUtils.func1 { row => ViewRow(row, reader) })
       Source.fromPublisher[ViewRow[T]](RxReactiveStreams.toPublisher[ViewRow[T]](obs))
     })
   }
 
-  def search[T](query: QueryLike)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[T, NotUsed] = {
+  def search[T](query: QueryLike, timeout: Option[Duration] = config.defaultTimeout)(implicit ec: ExecutionContext, mat: Materializer, reader: JsonReads[T]): QueryResult[T, NotUsed] = {
     SimpleQueryResult(() => {
       val obs: Observable[T] = query match {
         case N1qlQuery(n1ql, args) if args.isEmpty => {
           _asyncBucket.query(com.couchbase.client.java.query.N1qlQuery.simple(n1ql))
+            .maybeTimeout(timeout)
             .flatMap(RxUtils.func1(_.rows()))
             .map(RxUtils.func1 { t =>
               reader.reads(ByteString(t.byteValue())) match {
@@ -607,6 +611,7 @@ class Bucket(config: BucketConfig, onStop: () => Unit) {
         case N1qlQuery(n1ql, args) if args.nonEmpty => {
           val params: JsonObject = args.toJsonObject
           _asyncBucket.query(com.couchbase.client.java.query.N1qlQuery.parameterized(n1ql, params))
+            .maybeTimeout(timeout)
             .flatMap(RxUtils.func1(_.rows()))
             .map(RxUtils.func1 { t =>
               reader.reads(ByteString(t.byteValue())) match {

--- a/src/main/scala/org/reactivecouchbase/rs/scaladsl/ReactiveCouchbase.scala
+++ b/src/main/scala/org/reactivecouchbase/rs/scaladsl/ReactiveCouchbase.scala
@@ -5,21 +5,22 @@ import java.util.concurrent.{ConcurrentHashMap, Executors}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.reactivecouchbase.rs.scaladsl.TypeUtils.EnvCustomizer
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 class ReactiveCouchbase(val config: Config) {
 
   private val pool = new ConcurrentHashMap[String, Bucket]()
 
-  def bucket(name: String, env: EnvCustomizer = identity): Bucket = {
+  def bucket(name: String, env: EnvCustomizer = identity, defaultTimeout: Option[Duration] = None): Bucket = {
     pool.computeIfAbsent(name, JavaUtils.function { key =>
-      Bucket(BucketConfig(config.getConfig(s"buckets.$key"), env), () => pool.remove(name))
+      Bucket(BucketConfig(config.getConfig(s"buckets.$key"), env, defaultTimeout), () => pool.remove(name))
     })
   }
 
-  def configureAndPoolBucket(name: String, env: EnvCustomizer): Unit = {
+  def configureAndPoolBucket(name: String, env: EnvCustomizer, defaultTimeout: Option[Duration] = None): Unit = {
     pool.computeIfAbsent(name, JavaUtils.function { key =>
-      Bucket(BucketConfig(config.getConfig(s"buckets.$key"), env), () => pool.remove(name))
+      Bucket(BucketConfig(config.getConfig(s"buckets.$key"), env, defaultTimeout), () => pool.remove(name))
     })
     ()
   }

--- a/src/main/scala/org/reactivecouchbase/rs/scaladsl/package.scala
+++ b/src/main/scala/org/reactivecouchbase/rs/scaladsl/package.scala
@@ -30,6 +30,16 @@ package object scaladsl {
       )
       p.future
     }
+
+    /**
+      * Applies a timeout given Some[Duration], otherwise does nothing
+      *
+      * @param timeout: Optional [[scala.concurrent.duration.Duration]]
+      *
+      * @return obs Observable[T]
+      * */
+    def maybeTimeout(timeout: Option[Duration]): Observable[T] =
+      timeout.map(to => obs.timeout(to.length, to.unit)).getOrElse(obs)
   }
 
   implicit class EnhancedDuration(val duration: Duration) extends AnyVal {


### PR DESCRIPTION
Fixes #20 

When using this, I noticed that all of my operations had infinite timeouts. When researching, I saw that all asynchronous operations must use their own timeout value and cannot inherit from the client configuration options (as such I cannot use the EnvCustomizer):

https://developer.couchbase.com/documentation/server/4.6/sdk/java/client-settings.html#story-h2-4

This pull request allows for someone to provide an optional timeout value with any bucket call, as well as a default timeout in the bucket configuration. The changes should not break any existing use of the client (new version would continue to provide infinite timeouts by default).

I also added the option to add cas settings to the stream-based API calls for insert/upsert as they seemed to be missing these from the previous feature addition. 